### PR TITLE
Fix component tests

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,10 +1,16 @@
 import { TestBed } from '@angular/core/testing';
 import { AppComponent } from './app.component';
+import { RouterTestingModule } from '@angular/router/testing';
+import { TranslateModule } from '@ngx-translate/core';
 
 describe('AppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [AppComponent],
+      imports: [
+        AppComponent,
+        RouterTestingModule,
+        TranslateModule.forRoot()
+      ],
     }).compileComponents();
   });
 

--- a/src/app/pages/contacts/contacts.component.spec.ts
+++ b/src/app/pages/contacts/contacts.component.spec.ts
@@ -1,4 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { TranslateModule } from '@ngx-translate/core';
 
 import { ContactsComponent } from './contacts.component';
 
@@ -8,7 +10,11 @@ describe('ContactsComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ContactsComponent]
+      imports: [
+        ContactsComponent,
+        RouterTestingModule,
+        TranslateModule.forRoot()
+      ]
     })
     .compileComponents();
 

--- a/src/app/pages/home/home.component.spec.ts
+++ b/src/app/pages/home/home.component.spec.ts
@@ -1,4 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { TranslateModule } from '@ngx-translate/core';
 
 import { HomeComponent } from './home.component';
 
@@ -8,7 +10,11 @@ describe('HomeComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [HomeComponent]
+      imports: [
+        HomeComponent,
+        RouterTestingModule,
+        TranslateModule.forRoot()
+      ]
     })
     .compileComponents();
 

--- a/src/app/pages/status/status.component.spec.ts
+++ b/src/app/pages/status/status.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 
 import { StatusComponent } from './status.component';
 
@@ -8,7 +9,10 @@ describe('StatusComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [StatusComponent]
+      imports: [
+        StatusComponent,
+        RouterTestingModule
+      ]
     })
     .compileComponents();
 

--- a/src/app/shell/faq/faq.component.spec.ts
+++ b/src/app/shell/faq/faq.component.spec.ts
@@ -1,4 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { TranslateModule } from '@ngx-translate/core';
 
 import { FaqComponent } from './faq.component';
 
@@ -8,7 +10,11 @@ describe('FaqComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [FaqComponent]
+      imports: [
+        FaqComponent,
+        RouterTestingModule,
+        TranslateModule.forRoot()
+      ]
     })
     .compileComponents();
 

--- a/src/app/shell/footer/footer.component.spec.ts
+++ b/src/app/shell/footer/footer.component.spec.ts
@@ -1,4 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TranslateModule } from '@ngx-translate/core';
+import { RouterTestingModule } from '@angular/router/testing';
 
 import { FooterComponent } from './footer.component';
 
@@ -8,7 +10,11 @@ describe('FooterComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [FooterComponent]
+      imports: [
+        FooterComponent,
+        RouterTestingModule,
+        TranslateModule.forRoot()
+      ]
     })
     .compileComponents();
 

--- a/src/app/shell/language-selection/language-selection.component.spec.ts
+++ b/src/app/shell/language-selection/language-selection.component.spec.ts
@@ -1,4 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { TranslateModule } from '@ngx-translate/core';
 
 import { LanguageSelectionComponent } from './language-selection.component';
 
@@ -8,7 +10,11 @@ describe('LanguageSelectionComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [LanguageSelectionComponent]
+      imports: [
+        LanguageSelectionComponent,
+        RouterTestingModule,
+        TranslateModule.forRoot()
+      ]
     })
     .compileComponents();
 

--- a/src/app/shell/navigation/navigation.component.spec.ts
+++ b/src/app/shell/navigation/navigation.component.spec.ts
@@ -1,4 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { TranslateModule } from '@ngx-translate/core';
 
 import { NavigationComponent } from './navigation.component';
 
@@ -8,7 +10,11 @@ describe('NavigationComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [NavigationComponent]
+      imports: [
+        NavigationComponent,
+        RouterTestingModule,
+        TranslateModule.forRoot()
+      ]
     })
     .compileComponents();
 


### PR DESCRIPTION
## Summary
- update Angular tests to include RouterTestingModule and TranslateModule.forRoot

## Testing
- `npx ng test --watch=false` *(fails: Cannot start Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_6848cb2f594c832095b05c6702ff5c7c