### PR TITLE
Implement lazy loaded routes

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,6 +1,4 @@
 import { Routes } from '@angular/router';
-import { HomeComponent } from './pages/home/home.component';
-import { StatusComponent } from './pages/status/status.component';
 import { langRedirectGuard } from './shared/guards/lang-redirect.guard';
 import { LanguageDetectionComponent } from './shell/language-detection/language-detection.component';
 
@@ -10,8 +8,15 @@ export const routes: Routes = [
         path: ':lang',
         children: [
             { path: '', redirectTo: 'home', pathMatch: 'full' },
-            { path: 'home', component: HomeComponent, data: { scrollspy: true } },
-            { path: 'status', component: StatusComponent },
+            {
+                path: 'home',
+                loadComponent: () => import('./pages/home/home.component').then(m => m.HomeComponent),
+                data: { scrollspy: true }
+            },
+            {
+                path: 'status',
+                loadComponent: () => import('./pages/status/status.component').then(m => m.StatusComponent)
+            },
         ]
     },
     { path: '**', redirectTo: 'en', pathMatch: 'full' } // fallback

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -19,7 +19,7 @@
 
       <div class="space-y-12">
         @for (card of cards; track $index) {
-        <div class="grid grid-cols-1 lg:grid-cols-2 items-center gap-6">
+        <div class="grid grid-cols-1 lg:grid-cols-2 items-center gap-6 min-h-[400px]">
 
           <div [class.lg:order-2]="$index % 2 !== 0">
             <!-- <span class="text-sm text-yellow-500 uppercase tracking-widest mb-2 block">{{ '0' + ($index + 1) }}</span> -->


### PR DESCRIPTION
## Summary
- lazy load Home and Status pages
- avoid layout shift for cards on the home page with a minimum height

## Testing
- `npx ng test --watch=false` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_68533eb9c1948320910528efa991bac6