### PR TITLE
Fix heading order and contrast on status page

### DIFF
--- a/src/app/pages/status/status.component.html
+++ b/src/app/pages/status/status.component.html
@@ -1,6 +1,7 @@
 <section id="status" class="bg-violet-50  min-h-[calc(100vh-84px-277px)] py-16 px-4 text-gray-800">
     <div class="max-w-xl mx-auto bg-white rounded-xl shadow p-6">
       <h1 class="text-2xl font-bold mb-6 text-center">Проверка статуса заказа</h1>
+      <h2 class="sr-only">Форма проверки статуса</h2>
   
       <form (ngSubmit)="checkStatus()" [formGroup]="statusForm" class="space-y-4">
         <div>
@@ -9,7 +10,7 @@
             formControlName="orderId"
             type="text"
             placeholder="Например: 123456"
-            class="w-full px-4 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-sky-500"
+            class="w-full px-4 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-sky-500 placeholder-gray-600"
           />
           <div class="text-red-500 text-sm mt-1" *ngIf="statusForm.get('orderId')?.invalid && statusForm.get('orderId')?.touched">
             Введите номер заказа
@@ -22,7 +23,7 @@
             formControlName="pin"
             type="password"
             placeholder="4-значный код"
-            class="w-full px-4 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-sky-500"
+            class="w-full px-4 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-sky-500 placeholder-gray-600"
           />
           <div class="text-red-500 text-sm mt-1" *ngIf="statusForm.get('pin')?.invalid && statusForm.get('pin')?.touched">
             Введите код
@@ -46,7 +47,7 @@
         <p><strong>Дата приёма:</strong> {{ order.date }}</p>
       </div>
   
-      <div *ngIf="notFound" class="mt-6 text-red-600 font-medium">
+      <div *ngIf="notFound" class="mt-6 text-red-700 font-medium">
         Заказ не найден. Проверьте данные и попробуйте снова.
       </div>
     </div>


### PR DESCRIPTION
## Summary
- ensure headings follow a proper sequential order by adding a hidden `<h2>`
- improve contrast of placeholders and error message on the status form

## Testing
- `npm test` *(fails: Could not resolve "src/styles.scss")*

------
https://chatgpt.com/codex/tasks/task_e_68557036372083209e29edec974b2a06