### PR TITLE
Fix SSR redirect default to Spanish

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -23,7 +23,7 @@ export class AppComponent {
     @Inject(DOCUMENT) private document: Document
   ) {
     this.router.events.pipe(filter(e => e instanceof NavigationEnd)).subscribe(() => {
-      const lang = this.route.snapshot.firstChild?.paramMap.get('lang') ?? 'en';
+      const lang = this.route.snapshot.firstChild?.paramMap.get('lang') ?? 'es';
       this.translate.use(lang);
     });
 

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -22,7 +22,7 @@ export const appConfig: ApplicationConfig = {
     provideHttpClient(withInterceptorsFromDi(), withFetch()),
     provideClientHydration(withEventReplay()),
     TranslateModule.forRoot({
-      defaultLanguage: 'ru',
+      defaultLanguage: 'es',
       loader: {
         provide: TranslateLoader,
         useFactory: HttpLoaderFactory,

--- a/src/app/app.routes.server.ts
+++ b/src/app/app.routes.server.ts
@@ -1,6 +1,6 @@
 import { ServerRoute, RenderMode } from '@angular/ssr';
 
-const languages = ['en', 'ru'];
+const languages = ['es', 'vl', 'en', 'ru', 'ua'];
 
 export const serverRoutes: ServerRoute[] = [
   {

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -19,5 +19,5 @@ export const routes: Routes = [
             },
         ]
     },
-    { path: '**', redirectTo: 'en', pathMatch: 'full' } // fallback
+    { path: '**', redirectTo: 'es', pathMatch: 'full' } // fallback
 ];

--- a/src/app/shared/guards/lang-redirect.guard.ts
+++ b/src/app/shared/guards/lang-redirect.guard.ts
@@ -7,12 +7,12 @@ export const langRedirectGuard: CanActivateFn = () => {
   const router = inject(Router);
   const platformId = inject(PLATFORM_ID);
 
-  let lang = 'en';
+  let lang = 'es';
 
   if (isPlatformBrowser(platformId)) {
     const saved = localStorage.getItem('lang');
     const browserLang = navigator.language?.split('-')[0];
-    lang = saved || browserLang || 'en';
+    lang = saved || browserLang || 'es';
   }
 
   router.navigateByUrl(`/${lang}`);

--- a/src/app/shell/language-selection/language-selection.component.ts
+++ b/src/app/shell/language-selection/language-selection.component.ts
@@ -11,7 +11,7 @@ import { TranslateService } from '@ngx-translate/core';
 })
 export class LanguageSelectionComponent {
   open = false;
-  currentLang: string = 'en'; // Default language
+  currentLang: string = 'es'; // Default language
 
   languages = [
     { code: 'es', label: 'Español', flag: 'https://flagcdn.com/es.svg' },

--- a/src/app/shell/navigation/navigation.component.ts
+++ b/src/app/shell/navigation/navigation.component.ts
@@ -19,7 +19,7 @@ import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 export class NavigationComponent {
   protected showMenu: boolean = false;
   public active$: Observable<string | null> | null = null;
-  public currentLang: string = 'en'; // Default language
+  public currentLang: string = 'es'; // Default language
 
   protected fragmentExact: IsActiveMatchOptions = {
     matrixParams: 'exact', 

--- a/src/index.html
+++ b/src/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="es">
 <head>
   <meta charset="utf-8">
   <title>Chip</title>

--- a/src/server.ts
+++ b/src/server.ts
@@ -42,6 +42,11 @@ app.use(
   }),
 );
 
+// Redirect root requests to the default language
+app.get(['/', '/index.html'], (_req, res) => {
+  res.redirect(302, '/es');
+});
+
 /**
  * Handle all other requests by rendering the Angular application.
  */
@@ -62,6 +67,13 @@ app.use('/**', async (req, res, next) => {
     let html = await response.text();
 
     const path = req.url.toLowerCase();
+    const defaultLang = 'es';
+
+    // If path has no language prefix, redirect to default language
+    if (!/^\/([a-z]{2})(\/|$)/.test(path)) {
+      res.redirect(302, `/${defaultLang}${path === '/' ? '' : path}`);
+      return;
+    }
     type LangCode = 'es' | 'vl' | 'en' | 'ru' | 'ua';
     type LangMeta = {
       lang: string;
@@ -103,7 +115,7 @@ app.use('/**', async (req, res, next) => {
     };
 
     // Определение языка из URL
-    const code = (Object.keys(langMap).find(code => path.startsWith(`/${code}`)) as LangCode) ?? 'en';
+    const code = (Object.keys(langMap).find(code => path.startsWith(`/${code}`)) as LangCode) ?? defaultLang as LangCode;
     const meta = langMap[code];
 
     // Заменяем атрибут <html lang="">
@@ -173,7 +185,7 @@ if (isMainModule(import.meta.url)) {
   const port = Number(process.env['PORT'] || 4000);
 
   app.listen(port, '0.0.0.0', () => {
-    console.log(`Node Express server listening on http://---:${port}`);
+    console.log(`Node Express server listening on http://localhost:${port}`);
   });
 }
 


### PR DESCRIPTION
## Summary
- redirect `/` to Spanish version
- use Spanish as default language in i18n config
- adjust language guard and components to default to Spanish
- update server-side language handling

## Testing
- `npm test` *(fails: Application bundle generation failed)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68558aa77a0c8320a43965aa56a25697