### PR TITLE
Update footer Instagram link

### DIFF
--- a/src/app/shell/footer/footer.component.html
+++ b/src/app/shell/footer/footer.component.html
@@ -31,15 +31,28 @@
         <h4 class="text-xl font-semibold mb-2">
           {{ 'FOOTER.SOCIAL_MEDIA_TITLE' | translate }}
         </h4>
-        <div class="flex space-x-4 mt-2">
-          <a href="#" class="hover:text-blue-400 transition">
-            {{ 'FOOTER.SOCIAL_MEDIA_FB' | translate }}
-          </a>
-          <a href="#" class="hover:text-blue-400 transition">
+        <div class="flex items-center mt-2">
+          <a
+            href="https://www.instagram.com/chip.valencia?utm_source=qr&amp;igsh=b2Uzb3VyMTU0Mmdo"
+            class="hover:text-blue-400 transition flex items-center"
+          >
+            <svg
+              class="mr-2 size-5"
+              xmlns="http://www.w3.org/2000/svg"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <rect x="2" y="2" width="20" height="20" rx="5" ry="5"></rect>
+              <path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"></path>
+              <line x1="17.5" y1="6.5" x2="17.51" y2="6.5"></line>
+            </svg>
             {{ 'FOOTER.SOCIAL_MEDIA_IGM' | translate }}
-          </a>
-          <a href="#" class="hover:text-blue-400 transition">
-            {{ 'FOOTER.SOCIAL_MEDIA_TG' | translate }}
           </a>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- trim down social media to only Instagram
- use a white Instagram SVG icon with a direct link

## Testing
- `npm test --silent` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_68560270c5048320abcd59491b0fec33