### PR TITLE
Fix language switching with fragment

### DIFF
--- a/src/app/shell/language-selection/language-selection.component.ts
+++ b/src/app/shell/language-selection/language-selection.component.ts
@@ -29,17 +29,20 @@ export class LanguageSelectionComponent {
   }
 
   changeLang(lang: string) {
-      this.translate.use(lang);
-      // this.currentLang = lang;
-    
-      if (isPlatformBrowser(this.platformId)) {
-        localStorage?.setItem('lang', lang); // ✅ сохраняем язык
-      }
-    
-      const currentUrl = this.router.url;
-      const cleaned = currentUrl.replace(/^\/[a-z]{2}/, '');
-      this.open = false;
-      this.router.navigate([`/${lang}${cleaned}`]);
+    this.translate.use(lang);
+
+    if (isPlatformBrowser(this.platformId)) {
+      localStorage?.setItem('lang', lang); // ✅ сохраняем язык
+    }
+
+    const tree = this.router.parseUrl(this.router.url);
+    const segments = tree.root.children['primary']?.segments ?? [];
+    const pathSegments = segments.slice(1).map(s => s.path); // remove current lang
+
+    this.open = false;
+    this.router.navigate(['/', lang, ...pathSegments], {
+      fragment: tree.fragment ?? undefined
+    });
   }
 
   getLabel(code: string): string {


### PR DESCRIPTION
## Summary
- keep fragment when switching languages

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_6856a25a1fe08320bfe766bd9e2d42d6