### PR TITLE
Add backdrop and close controls to language selector

### DIFF
--- a/src/app/shell/language-selection/language-selection.component.html
+++ b/src/app/shell/language-selection/language-selection.component.html
@@ -1,7 +1,7 @@
-<div class="relative inline-block text-left" (clickOutside)="open = false">
+<div class="relative inline-block text-left">
     <button
       class="lang-selector inline-flex items-center justify-center w-full px-2 py-2 border border-gray-300 rounded text-sm font-medium text-white cursor-pointer focus:outline-none"
-      (click)="open = !open"
+      (click)="toggle()"
       type="button"
     >
       <img [src]="getFlag(currentLang)" alt="flag" class="w-5 h-5 rounded-full" />
@@ -11,17 +11,18 @@
       </svg>
     </button>
   @if (open) {
-      <div class="origin-top-right absolute right-0 mt-2 w-48 rounded-md shadow-lg bg-white ring-1 ring-grey ring-opacity-5 focus:outline-none z-50">
-        <div class="p-1">
-            @for (lang of languages; track $index) {
-                <button
-                    (click)="changeLang(lang.code)"
-                    class="flex items-center w-full px-4 py-2 text-sm text-gray-700 rounded-md hover:bg-[#525086] hover:text-white cursor-pointer">
-                    <img [src]="lang.flag" alt="flag" class="w-5 h-5 mr-2 rounded-full border border-gray-500" />
-                    {{ lang.label }}
-                </button>
-            }
-        </div>
+    <div class="fixed inset-0 bg-black/50 z-40" (click)="open = false"></div>
+    <div class="origin-top-right absolute right-0 mt-2 w-48 rounded-md shadow-lg bg-white ring-1 ring-grey ring-opacity-5 focus:outline-none z-50" (click)="$event.stopPropagation()">
+      <div class="p-1">
+        @for (lang of languages; track $index) {
+          <button
+            (click)="changeLang(lang.code)"
+            class="flex items-center w-full px-4 py-2 text-sm text-gray-700 rounded-md hover:bg-[#525086] hover:text-white cursor-pointer">
+            <img [src]="lang.flag" alt="flag" class="w-5 h-5 mr-2 rounded-full border border-gray-500" />
+            {{ lang.label }}
+          </button>
+        }
       </div>
+    </div>
   }
   </div>

--- a/src/app/shell/language-selection/language-selection.component.ts
+++ b/src/app/shell/language-selection/language-selection.component.ts
@@ -1,5 +1,5 @@
 import { isPlatformBrowser } from '@angular/common';
-import { Component, Inject, PLATFORM_ID } from '@angular/core';
+import { Component, ElementRef, HostListener, Inject, PLATFORM_ID } from '@angular/core';
 import { Router } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
 
@@ -21,11 +21,34 @@ export class LanguageSelectionComponent {
     { code: 'ua', label: 'Українська', flag: 'https://flagcdn.com/ua.svg' },
   ];
 
-  constructor(private translate: TranslateService, private router: Router, @Inject(PLATFORM_ID) private platformId: Object) {
+  constructor(
+    private translate: TranslateService,
+    private router: Router,
+    private el: ElementRef<HTMLElement>,
+    @Inject(PLATFORM_ID) private platformId: Object
+  ) {
     this.currentLang = this.translate.currentLang;
     this.translate.onLangChange.subscribe((event) => {
       this.currentLang = event.lang;
     });
+  }
+
+  toggle(): void {
+    this.open = !this.open;
+  }
+
+  @HostListener('document:click', ['$event'])
+  onDocumentClick(event: MouseEvent): void {
+    if (this.open && !this.el.nativeElement.contains(event.target as Node)) {
+      this.open = false;
+    }
+  }
+
+  @HostListener('document:keydown.escape', ['$event'])
+  onEscape(): void {
+    if (this.open) {
+      this.open = false;
+    }
   }
 
   changeLang(lang: string) {


### PR DESCRIPTION
## Summary
- add click/escape handling in language selector
- show a backdrop overlay on language dropdown

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_6856e63bc1cc8320af514409005f0c67