### PR TITLE
Improve mobile layout

### DIFF
--- a/src/app/pages/contacts/contacts.component.html
+++ b/src/app/pages/contacts/contacts.component.html
@@ -39,7 +39,7 @@
       <a
         href="https://www.google.com/maps/dir/?api=1&destination=Reparacion+de+portatiles+CHIP+Carrer+de+Jes%C3%BAs,+83,+46007+Val%C3%A8ncia"
         target="_blank"
-        class="inline-flex justify-center items-center max-w-[50%] border-solid border-2 border-yellow-600 mx-auto my-4 p-6 text-yellow-600 font-medium rounded shadow transition">
+        class="inline-flex justify-center items-center w-full sm:max-w-[50%] border-solid border-2 border-yellow-600 mx-auto my-4 px-6 py-4 text-yellow-600 font-medium rounded shadow transition">
         <span class="mr-5">
           <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-footprints-icon lucide-footprints"><path d="M4 16v-2.38C4 11.5 2.97 10.5 3 8c.03-2.72 1.49-6 4.5-6C9.37 2 10 3.8 10 5.5c0 3.11-2 5.66-2 8.68V16a2 2 0 1 1-4 0Z"/><path d="M20 20v-2.38c0-2.12 1.03-3.12 1-5.62-.03-2.72-1.49-6-4.5-6C14.63 6 14 7.8 14 9.5c0 3.11 2 5.66 2 8.68V20a2 2 0 1 0 4 0Z"/><path d="M16 17h4"/><path d="M4 13h4"/></svg>
         </span>

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -6,9 +6,9 @@
 </section>
 <div class="dark-horizontal">
   <section class="max-w-7xl mx-auto text-white px-4">
-    <div class=" p-24 dark-pattern-blur">
+    <div class="p-6 md:p-24 dark-pattern-blur">
       <header class="mb-16 header-background">
-        <h2 class="text-5xl font-bold leading-tight mb-6 text-center">
+        <h2 class="text-4xl md:text-5xl font-bold leading-tight mb-6 text-center">
           {{ 'HOME.TITLE' | translate }}
         </h2>
         <p class="text-lg text-gray-300 text-center mb-16 max-w-3xl mx-auto">


### PR DESCRIPTION
## Summary
- tweak padding and heading size on home page for better mobile layout
- widen directions button on contacts page

## Testing
- `npm test` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_685754cb97ec832093042b4e72a6970b