### PR TITLE
Replace flag icons with language codes

### DIFF
--- a/src/app/shell/language-selection/language-selection.component.html
+++ b/src/app/shell/language-selection/language-selection.component.html
@@ -4,7 +4,7 @@
       (click)="toggle()"
       type="button"
     >
-      <img [src]="getFlag(currentLang)" alt="flag" class="w-5 h-5 rounded-full" />
+      <span class="w-5 h-5 flex items-center justify-center rounded-full bg-gray-800 text-white text-[10px] font-semibold">{{ currentLang | uppercase }}</span>
       <!-- {{ getLabel(currentLang) }} -->
       <svg class="w-4 h-4 ml-2" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
@@ -18,7 +18,7 @@
           <button
             (click)="changeLang(lang.code)"
             class="flex items-center w-full px-4 py-2 text-sm text-gray-700 rounded-md hover:bg-[#525086] hover:text-white cursor-pointer">
-            <img [src]="lang.flag" alt="flag" class="w-5 h-5 mr-2 rounded-full border border-gray-500" />
+            <span class="w-5 h-5 mr-2 flex items-center justify-center rounded-full bg-gray-800 text-white text-[10px] font-semibold">{{ lang.code | uppercase }}</span>
             {{ lang.label }}
           </button>
         }

--- a/src/app/shell/language-selection/language-selection.component.ts
+++ b/src/app/shell/language-selection/language-selection.component.ts
@@ -1,11 +1,11 @@
-import { isPlatformBrowser } from '@angular/common';
+import { isPlatformBrowser, UpperCasePipe } from '@angular/common';
 import { Component, ElementRef, HostListener, Inject, PLATFORM_ID } from '@angular/core';
 import { Router } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
 
 @Component({
   selector: 'app-language-selection',
-  imports: [],
+  imports: [ UpperCasePipe ],
   templateUrl: './language-selection.component.html',
   styleUrl: './language-selection.component.scss'
 })

--- a/src/app/shell/language-selection/language-selection.component.ts
+++ b/src/app/shell/language-selection/language-selection.component.ts
@@ -14,11 +14,11 @@ export class LanguageSelectionComponent {
   currentLang: string = 'es'; // Default language
 
   languages = [
-    { code: 'es', label: 'Español', flag: 'https://flagcdn.com/es.svg' },
-    { code: 'vl', label: 'Valenciano', flag: '/flags/valencia.png' },
-    { code: 'en', label: 'English', flag: 'https://flagcdn.com/gb.svg' },
-    { code: 'ru', label: 'Русский', flag: 'https://flagcdn.com/ru.svg' },
-    { code: 'ua', label: 'Українська', flag: 'https://flagcdn.com/ua.svg' },
+    { code: 'es', label: 'Español' },
+    { code: 'vl', label: 'Valenciano' },
+    { code: 'en', label: 'English' },
+    { code: 'ru', label: 'Русский' },
+    { code: 'ua', label: 'Українська' },
   ];
 
   constructor(
@@ -70,9 +70,5 @@ export class LanguageSelectionComponent {
 
   getLabel(code: string): string {
     return this.languages.find(lang => lang.code === code)?.label || '';
-  }
-
-  getFlag(code: string): string {
-    return this.languages.find(lang => lang.code === code)?.flag || '';
   }
 }


### PR DESCRIPTION
## Summary
- show language code abbreviations instead of flag images in the language selector

## Testing
- `npm test --silent` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_6857e89179c48320a18a09f0f986bd86