### PR TITLE
Fix navigation links for sections

### DIFF
--- a/src/app/shell/navigation/navigation.component.ts
+++ b/src/app/shell/navigation/navigation.component.ts
@@ -89,6 +89,9 @@ export class NavigationComponent {
   }
 
   public getRouterLink(section: string): string | undefined {
-    return `/${this.currentLangSubject.value}/${section}`;
+    if(section === 'status') {
+      return `/${this.currentLangSubject.value}/status`;
+    }
+    return `/${this.currentLangSubject.value}/home`;
   }
 }


### PR DESCRIPTION
## Summary
- correct router link generation for in-page sections to stay on current language

## Testing
- `npm test -- --watch=false` *(fails: Chrome not found)*

------
https://chatgpt.com/codex/tasks/task_e_685939b2fa0483208782fdeb1501730c