### PR TITLE
Fix missing subscription cleanup

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,10 +1,10 @@
-import { Component, Inject, DOCUMENT } from '@angular/core';
+import { Component, Inject, DOCUMENT, OnDestroy } from '@angular/core';
 import { ActivatedRoute, NavigationEnd, Router, RouterOutlet } from '@angular/router';
 import { NavigationComponent } from './shell/navigation/navigation.component';
 import { FooterComponent } from './shell/footer/footer.component';
 import { NgbScrollSpyModule } from '@ng-bootstrap/ng-bootstrap';
 import { TranslateService } from '@ngx-translate/core';
-import { filter } from 'rxjs';
+import { filter, Subject, takeUntil } from 'rxjs';
 
 
 @Component({
@@ -14,21 +14,30 @@ import { filter } from 'rxjs';
   templateUrl: './app.component.html',
   styleUrl: './app.component.scss'
 })
-export class AppComponent {
+export class AppComponent implements OnDestroy {
   title = 'chip';
+  private destroy$ = new Subject<void>();
   constructor(
     private route: ActivatedRoute,
     private router: Router,
     private translate: TranslateService,
     @Inject(DOCUMENT) private document: Document
   ) {
-    this.router.events.pipe(filter(e => e instanceof NavigationEnd)).subscribe(() => {
+    this.router.events.pipe(
+      filter(e => e instanceof NavigationEnd),
+      takeUntil(this.destroy$)
+    ).subscribe(() => {
       const lang = this.route.snapshot.firstChild?.paramMap.get('lang') ?? 'es';
       this.translate.use(lang);
     });
 
-    this.translate.onLangChange.subscribe(e => {
+    this.translate.onLangChange.pipe(takeUntil(this.destroy$)).subscribe(e => {
       this.document.documentElement.lang = e.lang;
     });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
   }
 }

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject, PLATFORM_ID } from '@angular/core';
+import { Component, Inject, PLATFORM_ID, OnDestroy, AfterViewInit } from '@angular/core';
 import { FaqComponent } from '../faq/faq.component';
 import { ContactsComponent } from "../contacts/contacts.component";
 import { isPlatformBrowser } from '@angular/common';
@@ -6,6 +6,7 @@ import { ActivatedRoute } from '@angular/router';
 import { NgbScrollSpyModule } from '@ng-bootstrap/ng-bootstrap';
 import { ScrollspyDirective } from '../../shared/directives/scrollspy.directive';
 import { TranslateModule } from '@ngx-translate/core';
+import { Subject, takeUntil } from 'rxjs';
 
 @Component({
   selector: 'app-home',
@@ -14,7 +15,7 @@ import { TranslateModule } from '@ngx-translate/core';
   templateUrl: './home.component.html',
   styleUrl: './home.component.scss'
 })
-export class HomeComponent {
+export class HomeComponent implements AfterViewInit, OnDestroy {
 
 cards = [
   {
@@ -56,15 +57,17 @@ cards = [
 ];
 
   constructor(
-    private route: ActivatedRoute, 
+    private route: ActivatedRoute,
     @Inject(PLATFORM_ID) private platformId: Object,
   ) {
 
   }
 
+  private destroy$ = new Subject<void>();
+
   ngAfterViewInit() {
     if (isPlatformBrowser(this.platformId)) {
-        this.route.fragment.subscribe((fragment) => {
+        this.route.fragment.pipe(takeUntil(this.destroy$)).subscribe((fragment) => {
           if(fragment) {
             const container = document.getElementById('mainContent');
             const target = document.getElementById(fragment);
@@ -75,8 +78,13 @@ cards = [
             }
           }
         });
-      
+
     }
-    
+
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
   }
 }

--- a/src/app/pages/status/status.component.ts
+++ b/src/app/pages/status/status.component.ts
@@ -1,7 +1,8 @@
-import { Component, Inject, PLATFORM_ID } from '@angular/core';
+import { Component, Inject, PLATFORM_ID, OnDestroy, AfterViewInit } from '@angular/core';
 import { ReactiveFormsModule, FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { CommonModule, isPlatformBrowser, ViewportScroller } from '@angular/common';
 import { RouterModule, ActivatedRoute } from '@angular/router';
+import { Subject, takeUntil } from 'rxjs';
 
 @Component({
   selector: 'app-status',
@@ -10,14 +11,14 @@ import { RouterModule, ActivatedRoute } from '@angular/router';
   templateUrl: './status.component.html',
   styleUrl: './status.component.scss'
 })
-export class StatusComponent {
+export class StatusComponent implements AfterViewInit, OnDestroy {
   statusForm: FormGroup;
   order: any = null;
   notFound = false;
 
   constructor(
-    private fb: FormBuilder, 
-    private route: ActivatedRoute, 
+    private fb: FormBuilder,
+    private route: ActivatedRoute,
     @Inject(PLATFORM_ID) private platformId: Object,
     private scroller: ViewportScroller
   ) {
@@ -27,10 +28,12 @@ export class StatusComponent {
     });
   }
 
+  private destroy$ = new Subject<void>();
+
   ngAfterViewInit() {
     if (isPlatformBrowser(this.platformId)) {
 
-        this.route.fragment.subscribe((fragment) => {
+        this.route.fragment.pipe(takeUntil(this.destroy$)).subscribe((fragment) => {
           // console.log('Fragment:', fragment);
           if(fragment) {
             const container = document.getElementById('mainContent');
@@ -42,9 +45,9 @@ export class StatusComponent {
             }
           }
         });
-      
+
     }
-    
+
   }
 
   checkStatus() {
@@ -65,4 +68,8 @@ export class StatusComponent {
     }
   }
 
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
 }

--- a/src/app/shell/language-selection/language-selection.component.ts
+++ b/src/app/shell/language-selection/language-selection.component.ts
@@ -1,7 +1,8 @@
 import { isPlatformBrowser, UpperCasePipe } from '@angular/common';
-import { Component, ElementRef, HostListener, Inject, PLATFORM_ID } from '@angular/core';
+import { Component, ElementRef, HostListener, Inject, PLATFORM_ID, OnDestroy } from '@angular/core';
 import { Router } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
+import { Subject, takeUntil } from 'rxjs';
 
 @Component({
   selector: 'app-language-selection',
@@ -9,9 +10,11 @@ import { TranslateService } from '@ngx-translate/core';
   templateUrl: './language-selection.component.html',
   styleUrl: './language-selection.component.scss'
 })
-export class LanguageSelectionComponent {
+export class LanguageSelectionComponent implements OnDestroy {
   open = false;
   currentLang: string = 'es'; // Default language
+
+  private destroy$ = new Subject<void>();
 
   languages = [
     { code: 'es', label: 'Español' },
@@ -28,7 +31,7 @@ export class LanguageSelectionComponent {
     @Inject(PLATFORM_ID) private platformId: Object
   ) {
     this.currentLang = this.translate.currentLang;
-    this.translate.onLangChange.subscribe((event) => {
+    this.translate.onLangChange.pipe(takeUntil(this.destroy$)).subscribe((event) => {
       this.currentLang = event.lang;
     });
   }
@@ -71,5 +74,10 @@ export class LanguageSelectionComponent {
 
   getLabel(code: string): string {
     return this.languages.find(lang => lang.code === code)?.label || '';
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
   }
 }


### PR DESCRIPTION
## Summary
- use `takeUntil` for `AppComponent`
- add unsubscribe logic to Home page scroll logic
- ensure Status page scroll logic unsubscribes
- clean up language selection subscriptions

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68593c81e49883209ed453ddb4358e50