### PR TITLE
Fix FAQ answers not rendered

### DIFF
--- a/src/app/pages/faq/faq.component.html
+++ b/src/app/pages/faq/faq.component.html
@@ -24,16 +24,15 @@
           </svg>
         </button>
 
-        @if (openedIndex === i) {
-            <div
-            class="mt-3 text-white"
-            itemscope
-            itemprop="acceptedAnswer"
-            itemtype="https://schema.org/Answer"
-          >
-            <p itemprop="text">{{ faq.answer | translate }}</p>
-          </div>
-        }
+        <div
+          class="mt-3 text-white"
+          itemscope
+          itemprop="acceptedAnswer"
+          itemtype="https://schema.org/Answer"
+          [style.display]="openedIndex === i ? 'block' : 'none'"
+        >
+          <p itemprop="text">{{ faq.answer | translate }}</p>
+        </div>
       </div>
     }
 


### PR DESCRIPTION
## Summary
- ensure FAQ answers are always in the DOM so Google can read them

## Testing
- `npm test` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_685a7c26ba18832088024a75ae265e03