### PR TITLE
Add hero video background

### DIFF
--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -1,8 +1,8 @@
 <section [appScrollSpy]="'home'" id="home" class="relative text-white">
-  <video autoplay muted loop playsinline class="absolute inset-0 w-full h-full object-cover">
+  <video muted loop playsinline autoplay class="absolute inset-0 w-full h-full object-cover">
     <source src="/video/hero-loop.mp4" type="video/mp4" />
   </video>
-  <div class="bg-black/60 flex flex-col items-center justify-center py-40 px-4 text-center relative">
+  <div class="bg-black/60 flex flex-col items-center justify-center py-70 px-4 text-center relative">
     <h1 class="text-5xl font-bold mb-4">{{ 'HOME.HERO_TITLE' | translate }}</h1>
     <p class="text-xl">{{ 'HOME.HERO_SUBTITLE' | translate }}</p>
   </div>

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -1,5 +1,8 @@
-<section [appScrollSpy]="'home'" id="home" class="relative bg-cover bg-center text-white" style="background-image: url('/images/mobile-repair.jpg');">
-  <div class="bg-black/60 flex flex-col items-center justify-center py-40 px-4 text-center">
+<section [appScrollSpy]="'home'" id="home" class="relative text-white">
+  <video autoplay muted loop playsinline class="absolute inset-0 w-full h-full object-cover">
+    <source src="/video/hero-loop.mp4" type="video/mp4" />
+  </video>
+  <div class="bg-black/60 flex flex-col items-center justify-center py-40 px-4 text-center relative">
     <h1 class="text-5xl font-bold mb-4">{{ 'HOME.HERO_TITLE' | translate }}</h1>
     <p class="text-xl">{{ 'HOME.HERO_SUBTITLE' | translate }}</p>
   </div>

--- a/src/index.html
+++ b/src/index.html
@@ -13,7 +13,7 @@
   <link rel="alternate" hreflang="ru" href="https://chip-valencia.es/ru" />
   <link rel="alternate" hreflang="es" href="https://chip-valencia.es/es" />
   <link rel="alternate" hreflang="uk" href="https://chip-valencia.es/uk" />
-  <link rel="preload" fetchpriority="high" as="image" href="/images/mobile-repair.jpg">
+  <link rel="preload" fetchpriority="high" as="video" href="/video/hero-loop.mp4" type="video/mp4">
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-BEZC3CZ1LN"></script>
   <script>


### PR DESCRIPTION
## Summary
- replace hero section background image with looping video
- preload the video in `index.html`

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_685a9a6ec30083209b6514cbc058d92e