### PR TITLE
Fix canonical tag

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -118,6 +118,12 @@ app.use('/**', async (req, res, next) => {
     const code = (Object.keys(langMap).find(code => path.startsWith(`/${code}`)) as LangCode) ?? defaultLang as LangCode;
     const meta = langMap[code];
 
+    // Обновляем canonical-ссылку в соответствии с текущим путём
+    html = html.replace(
+      /<link rel="canonical"[^>]*>/i,
+      `<link rel="canonical" href="https://chip-valencia.es${path}">`,
+    );
+
     // Заменяем атрибут <html lang="">
     html = html.replace('<html ', `<html lang="${meta.lang}" `);
 


### PR DESCRIPTION
## Summary
- update canonical link in server to build href dynamically

## Testing
- `npm test` *(fails: Chrome binary missing)*

------
https://chatgpt.com/codex/tasks/task_e_685a9ab376f08320a4367a1fdb9fc5e1