### PR TITLE
Fix hero video pause after hydration

### DIFF
--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -1,5 +1,5 @@
 <section [appScrollSpy]="'home'" id="home" class="relative text-white">
-  <video muted loop playsinline autoplay class="absolute inset-0 w-full h-full object-cover">
+  <video #heroVideo muted loop playsinline autoplay class="absolute inset-0 w-full h-full object-cover">
     <source src="/video/hero-loop.mp4" type="video/mp4" />
   </video>
   <div class="bg-black/60 flex flex-col items-center justify-center py-70 px-4 text-center relative">

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject, PLATFORM_ID, OnDestroy, AfterViewInit } from '@angular/core';
+import { Component, Inject, PLATFORM_ID, OnDestroy, AfterViewInit, ElementRef, ViewChild } from '@angular/core';
 import { FaqComponent } from '../faq/faq.component';
 import { ContactsComponent } from "../contacts/contacts.component";
 import { isPlatformBrowser } from '@angular/common';
@@ -16,6 +16,10 @@ import { Subject, takeUntil } from 'rxjs';
   styleUrl: './home.component.scss'
 })
 export class HomeComponent implements AfterViewInit, OnDestroy {
+
+  @ViewChild('heroVideo') heroVideo?: ElementRef<HTMLVideoElement>;
+
+  private playListener?: () => void;
 
 cards = [
   {
@@ -67,6 +71,12 @@ cards = [
 
   ngAfterViewInit() {
     if (isPlatformBrowser(this.platformId)) {
+        const videoEl = this.heroVideo?.nativeElement;
+        this.playListener = () => videoEl?.play().catch(() => {});
+        if (videoEl) {
+          videoEl.addEventListener('canplay', this.playListener);
+          setTimeout(this.playListener);
+        }
         this.route.fragment.pipe(takeUntil(this.destroy$)).subscribe((fragment) => {
           if(fragment) {
             const container = document.getElementById('mainContent');
@@ -84,6 +94,12 @@ cards = [
   }
 
   ngOnDestroy(): void {
+    if (isPlatformBrowser(this.platformId)) {
+      const videoEl = this.heroVideo?.nativeElement;
+      if (videoEl && this.playListener) {
+        videoEl.removeEventListener('canplay', this.playListener);
+      }
+    }
     this.destroy$.next();
     this.destroy$.complete();
   }


### PR DESCRIPTION
## Summary
- add `#heroVideo` reference for the hero video
- ensure the video plays after client hydration using a `canplay` listener

## Testing
- `npx tsc -p tsconfig.json`
- `npm test -- --watch=false` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_685aefb59a0c8320bdd80338a206415a