### PR TITLE
Add lazy loading to home images

### DIFF
--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -28,7 +28,7 @@
           </div>
 
           <div [class.lg:order-1]="$index % 2 !== 0">
-            <img [src]="card.image" [attr.alt]="card.alt | translate" style="aspect-ratio: 16 / 9;"
+            <img loading="lazy" [src]="card.image" [attr.alt]="card.alt | translate" style="aspect-ratio: 16 / 9;"
               class="rounded-xl shadow-lg w-full object-cover max-h-[400px]" />
           </div>
 


### PR DESCRIPTION
## Summary
- lazy load images on the home page
- confirm build output retains `loading="lazy"`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685a9adf41d88320a43e862939b6fbc4