### PR TITLE
Fix layout shift issues

### DIFF
--- a/src/app/pages/status/status.component.html
+++ b/src/app/pages/status/status.component.html
@@ -39,16 +39,18 @@
         </button>
       </form>
   
-      <div *ngIf="order" class="mt-6 p-4 border rounded-md bg-violet-100">
-        <h2 class="font-semibold mb-2">Информация о заказе</h2>
-        <p><strong>Номер:</strong> {{ order.id }}</p>
-        <p><strong>Устройство:</strong> {{ order.device }}</p>
-        <p><strong>Статус:</strong> {{ order.status }}</p>
-        <p><strong>Дата приёма:</strong> {{ order.date }}</p>
-      </div>
-  
-      <div *ngIf="notFound" class="mt-6 text-red-700 font-medium">
-        Заказ не найден. Проверьте данные и попробуйте снова.
+      <div class="mt-6 min-h-32">
+        <div *ngIf="order" class="p-4 border rounded-md bg-violet-100">
+          <h2 class="font-semibold mb-2">Информация о заказе</h2>
+          <p><strong>Номер:</strong> {{ order.id }}</p>
+          <p><strong>Устройство:</strong> {{ order.device }}</p>
+          <p><strong>Статус:</strong> {{ order.status }}</p>
+          <p><strong>Дата приёма:</strong> {{ order.date }}</p>
+        </div>
+
+        <div *ngIf="notFound" class="text-red-700 font-medium">
+          Заказ не найден. Проверьте данные и попробуйте снова.
+        </div>
       </div>
     </div>
   </section>

--- a/src/app/shell/language-selection/language-selection.component.html
+++ b/src/app/shell/language-selection/language-selection.component.html
@@ -1,4 +1,4 @@
-<div class="relative inline-block text-left">
+<div class="relative inline-block text-left w-10">
     <button
       class="lang-selector inline-flex items-center justify-center w-full px-2 py-2 border border-gray-300 rounded text-sm font-medium text-white cursor-pointer focus:outline-none"
       (click)="toggle()"


### PR DESCRIPTION
## Summary
- ensure status page reserves space before order details
- fix width of language selector to avoid layout jumping

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_685b549618108320962ce2ad9e31992c