### PR TITLE
Implement synchronous i18n init using TransferState

### DIFF
--- a/src/app/app.config.server.ts
+++ b/src/app/app.config.server.ts
@@ -1,13 +1,11 @@
 import { provideServerRendering, withRoutes } from '@angular/ssr';
-import { importProvidersFrom, mergeApplicationConfig, ApplicationConfig } from '@angular/core';
-import { ServerTransferStateModule } from '@angular/platform-server';
+import { mergeApplicationConfig, ApplicationConfig } from '@angular/core';
 import { appConfig } from './app.config';
 import { serverRoutes } from './app.routes.server';
 
 const serverConfig: ApplicationConfig = {
   providers: [
-    provideServerRendering(withRoutes(serverRoutes)),
-    importProvidersFrom(ServerTransferStateModule)
+    provideServerRendering(withRoutes(serverRoutes))
   ]
 };
 

--- a/src/app/app.config.server.ts
+++ b/src/app/app.config.server.ts
@@ -1,10 +1,14 @@
 import { provideServerRendering, withRoutes } from '@angular/ssr';
-import { mergeApplicationConfig, ApplicationConfig } from '@angular/core';
+import { importProvidersFrom, mergeApplicationConfig, ApplicationConfig } from '@angular/core';
+import { ServerTransferStateModule } from '@angular/platform-server';
 import { appConfig } from './app.config';
 import { serverRoutes } from './app.routes.server';
 
 const serverConfig: ApplicationConfig = {
-  providers: [provideServerRendering(withRoutes(serverRoutes))]
+  providers: [
+    provideServerRendering(withRoutes(serverRoutes)),
+    importProvidersFrom(ServerTransferStateModule)
+  ]
 };
 
 export const config = mergeApplicationConfig(appConfig, serverConfig);

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,7 +1,7 @@
-import { ApplicationConfig, APP_INITIALIZER, importProvidersFrom, provideZoneChangeDetection } from '@angular/core';
+import { ApplicationConfig, APP_INITIALIZER, provideZoneChangeDetection } from '@angular/core';
 import { PreloadAllModules, provideRouter, withPreloading } from '@angular/router';
 import { routes } from './app.routes';
-import { BrowserTransferStateModule, TransferState } from '@angular/platform-browser';
+import { TransferState } from '@angular/platform-browser';
 import { provideClientHydration, withEventReplay } from '@angular/platform-browser';
 import { HttpClient, provideHttpClient, withFetch, withInterceptorsFromDi } from '@angular/common/http';
 import {
@@ -39,7 +39,6 @@ export const appConfig: ApplicationConfig = {
         deps: [HttpClient, TransferState]
       }
     }).providers!,
-    importProvidersFrom(BrowserTransferStateModule),
     {
       provide: APP_INITIALIZER,
       useFactory: initTranslate,

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,18 +1,27 @@
-import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import { ApplicationConfig, APP_INITIALIZER, importProvidersFrom, provideZoneChangeDetection } from '@angular/core';
 import { PreloadAllModules, provideRouter, withPreloading } from '@angular/router';
 import { routes } from './app.routes';
+import { BrowserTransferStateModule, TransferState } from '@angular/platform-browser';
 import { provideClientHydration, withEventReplay } from '@angular/platform-browser';
-import { HttpBackend, HttpClient, provideHttpClient, withFetch, withInterceptorsFromDi } from '@angular/common/http';
+import { HttpClient, provideHttpClient, withFetch, withInterceptorsFromDi } from '@angular/common/http';
 import {
   TranslateLoader,
-  TranslateModule
+  TranslateModule,
+  TranslateService
 } from '@ngx-translate/core';
-import {
-  TranslateHttpLoader
-} from '@ngx-translate/http-loader';
+import { firstValueFrom } from 'rxjs';
+import { TransferTranslateLoader } from './shared/transfer-translate-loader';
 
-export function HttpLoaderFactory(http: HttpClient) {
-  return new TranslateHttpLoader(http, './i18n/', '.json');
+export function HttpLoaderFactory(http: HttpClient, transferState: TransferState) {
+  return new TransferTranslateLoader(http, transferState);
+}
+
+export function initTranslate(translate: TranslateService) {
+  return () => {
+    const lang = document?.documentElement.lang || 'es';
+    translate.setDefaultLang(lang);
+    return firstValueFrom(translate.use(lang));
+  };
 }
 
 
@@ -27,8 +36,15 @@ export const appConfig: ApplicationConfig = {
       loader: {
         provide: TranslateLoader,
         useFactory: HttpLoaderFactory,
-        deps: [HttpClient, HttpBackend]
+        deps: [HttpClient, TransferState]
       }
-    }).providers!
+    }).providers!,
+    importProvidersFrom(BrowserTransferStateModule),
+    {
+      provide: APP_INITIALIZER,
+      useFactory: initTranslate,
+      deps: [TranslateService],
+      multi: true
+    }
   ]
 };

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -11,14 +11,15 @@ import {
 } from '@ngx-translate/core';
 import { firstValueFrom } from 'rxjs';
 import { TransferTranslateLoader } from './shared/transfer-translate-loader';
+import { DOCUMENT } from '@angular/common';
 
 export function HttpLoaderFactory(http: HttpClient, transferState: TransferState) {
   return new TransferTranslateLoader(http, transferState);
 }
 
-export function initTranslate(translate: TranslateService) {
+export function initTranslate(translate: TranslateService, doc: Document) {
   return () => {
-    const lang = document?.documentElement.lang || 'es';
+    const lang = doc.documentElement.lang || 'es';
     translate.setDefaultLang(lang);
     return firstValueFrom(translate.use(lang));
   };
@@ -42,7 +43,7 @@ export const appConfig: ApplicationConfig = {
     {
       provide: APP_INITIALIZER,
       useFactory: initTranslate,
-      deps: [TranslateService],
+      deps: [TranslateService, DOCUMENT],
       multi: true
     }
   ]

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,7 +1,6 @@
-import { ApplicationConfig, APP_INITIALIZER, provideZoneChangeDetection } from '@angular/core';
+import { ApplicationConfig, APP_INITIALIZER, provideZoneChangeDetection, TransferState } from '@angular/core';
 import { PreloadAllModules, provideRouter, withPreloading } from '@angular/router';
 import { routes } from './app.routes';
-import { TransferState } from '@angular/platform-browser';
 import { provideClientHydration, withEventReplay } from '@angular/platform-browser';
 import { HttpClient, provideHttpClient, withFetch, withInterceptorsFromDi } from '@angular/common/http';
 import {

--- a/src/app/shared/guards/lang-redirect.guard.ts
+++ b/src/app/shared/guards/lang-redirect.guard.ts
@@ -9,11 +9,13 @@ export const langRedirectGuard: CanActivateFn = () => {
   const platformId = inject(PLATFORM_ID);
 
   let lang = 'es';
-
   if (isPlatformBrowser(platformId)) {
+    const htmlLang = document?.documentElement.lang;
     const saved = localStorage.getItem('lang');
     const browserLang = navigator.language?.split('-')[0];
-    lang = saved || browserLang || 'es';
+    lang = saved || browserLang || htmlLang || 'es';
+  } else {
+    lang = (globalThis as any)?.document?.documentElement?.lang || 'es';
   }
 
   router.navigateByUrl(`/${lang}`);

--- a/src/app/shared/guards/lang-redirect.guard.ts
+++ b/src/app/shared/guards/lang-redirect.guard.ts
@@ -1,21 +1,22 @@
 import { inject } from '@angular/core';
 import { CanActivateFn, Router } from '@angular/router';
 import { PLATFORM_ID } from '@angular/core';
-import { isPlatformBrowser } from '@angular/common';
+import { isPlatformBrowser, DOCUMENT } from '@angular/common';
 
 export const langRedirectGuard: CanActivateFn = () => {
     // console.log('lang >>>>> >>>>>>> ############################################');
   const router = inject(Router);
   const platformId = inject(PLATFORM_ID);
+  const doc = inject(DOCUMENT);
 
   let lang = 'es';
   if (isPlatformBrowser(platformId)) {
-    const htmlLang = document?.documentElement.lang;
+    const htmlLang = doc?.documentElement.lang;
     const saved = localStorage.getItem('lang');
     const browserLang = navigator.language?.split('-')[0];
     lang = saved || browserLang || htmlLang || 'es';
   } else {
-    lang = (globalThis as any)?.document?.documentElement?.lang || 'es';
+    lang = doc?.documentElement.lang || 'es';
   }
 
   router.navigateByUrl(`/${lang}`);

--- a/src/app/shared/transfer-translate-loader.ts
+++ b/src/app/shared/transfer-translate-loader.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { TransferState, makeStateKey } from '@angular/platform-browser';
+import { TranslateLoader } from '@ngx-translate/core';
+import { Observable, of } from 'rxjs';
+import { tap } from 'rxjs/operators';
+
+@Injectable()
+export class TransferTranslateLoader implements TranslateLoader {
+  constructor(private http: HttpClient, private transferState: TransferState) {}
+
+  getTranslation(lang: string): Observable<any> {
+    const key = makeStateKey<any>('transfer-translate-' + lang);
+    const data = this.transferState.get(key, null);
+    if (data) {
+      return of(data);
+    }
+    return this.http.get<any>(`./i18n/${lang}.json`).pipe(
+      tap(translation => this.transferState.set(key, translation))
+    );
+  }
+}

--- a/src/app/shared/transfer-translate-loader.ts
+++ b/src/app/shared/transfer-translate-loader.ts
@@ -1,6 +1,5 @@
-import { Injectable } from '@angular/core';
+import { Injectable, makeStateKey, TransferState } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { TransferState, makeStateKey } from '@angular/platform-browser';
 import { TranslateLoader } from '@ngx-translate/core';
 import { Observable, of } from 'rxjs';
 import { tap } from 'rxjs/operators';


### PR DESCRIPTION
## Summary
- implement `TransferTranslateLoader` that caches translations in Angular TransferState
- use TransferState in client/server configs and initialize TranslateService synchronously
- adjust language redirect guard to read initial language from `<html lang>`

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_685bcab049f48320a6e0cac1b2602f7f