### PR TITLE
Fix undefined lang redirects

### DIFF
--- a/src/app/shared/guards/lang-redirect.guard.ts
+++ b/src/app/shared/guards/lang-redirect.guard.ts
@@ -2,6 +2,7 @@ import { inject } from '@angular/core';
 import { CanActivateFn, Router } from '@angular/router';
 import { PLATFORM_ID } from '@angular/core';
 import { isPlatformBrowser, DOCUMENT } from '@angular/common';
+import { SUPPORTED_LANGUAGES, LangCode } from '../languages';
 
 export const langRedirectGuard: CanActivateFn = () => {
     // console.log('lang >>>>> >>>>>>> ############################################');
@@ -9,14 +10,21 @@ export const langRedirectGuard: CanActivateFn = () => {
   const platformId = inject(PLATFORM_ID);
   const doc = inject(DOCUMENT);
 
-  let lang = 'es';
+  let lang: LangCode = 'es';
   if (isPlatformBrowser(platformId)) {
     const htmlLang = doc?.documentElement.lang;
     const saved = localStorage.getItem('lang');
     const browserLang = navigator.language?.split('-')[0];
-    lang = saved || browserLang || htmlLang || 'es';
+
+    const candidate = [saved, browserLang, htmlLang].find(l =>
+      l && SUPPORTED_LANGUAGES.includes(l as LangCode)
+    );
+    lang = (candidate as LangCode) || 'es';
   } else {
-    lang = doc?.documentElement.lang || 'es';
+    const htmlLang = doc?.documentElement.lang;
+    if (htmlLang && SUPPORTED_LANGUAGES.includes(htmlLang as LangCode)) {
+      lang = htmlLang as LangCode;
+    }
   }
 
   router.navigateByUrl(`/${lang}`);

--- a/src/app/shared/languages.ts
+++ b/src/app/shared/languages.ts
@@ -1,0 +1,2 @@
+export const SUPPORTED_LANGUAGES = ['es', 'vl', 'en', 'ru', 'ua'] as const;
+export type LangCode = typeof SUPPORTED_LANGUAGES[number];

--- a/src/app/shell/navigation/navigation.component.ts
+++ b/src/app/shell/navigation/navigation.component.ts
@@ -8,6 +8,7 @@ import { Helper } from '../../shared/helper';
 import { BehaviorSubject, combineLatest, filter, map, Observable } from 'rxjs';
 import { ScrollSpyService } from '../../shared/services/scrollspy/scrollSpy.service';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
+import { SUPPORTED_LANGUAGES, LangCode } from '../../shared/languages';
 
 @Component({
   selector: 'app-navigation',
@@ -53,10 +54,12 @@ export class NavigationComponent {
 
     this.route.paramMap.subscribe(params => {
       const lang = params.get('lang');
-      if (lang) {
+      if (lang && SUPPORTED_LANGUAGES.includes(lang as LangCode)) {
         this.currentLangSubject.next(lang);
-        this.cdr.markForCheck();
+      } else {
+        this.currentLangSubject.next('es');
       }
+      this.cdr.markForCheck();
     });
   }
 
@@ -74,10 +77,13 @@ export class NavigationComponent {
 
   }
 
-  public getRouterLink(section: string): string | undefined {
-    if(section === 'status') {
-      return `/${this.currentLangSubject.value}/status`;
-    }
-    return `/${this.currentLangSubject.value}/home`;
+  public getRouterLink(section: string): string {
+    const lang = SUPPORTED_LANGUAGES.includes(this.currentLangSubject.value as LangCode)
+      ? this.currentLangSubject.value
+      : 'es';
+
+    return section === 'status'
+      ? `/${lang}/status`
+      : `/${lang}/home`;
   }
 }


### PR DESCRIPTION
## Summary
- ensure supported language guard for redirects
- expose SUPPORTED_LANGUAGES constant
- validate lang param in navigation component
- fix canonical URL generation on the server

## Testing
- `npm test --silent` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_685c1a068238832095787affd4ba550f