### PR TITLE
Improve navbar and language dropdown

### DIFF
--- a/src/app/shell/language-selection/language-selection.component.html
+++ b/src/app/shell/language-selection/language-selection.component.html
@@ -1,11 +1,10 @@
 <div class="relative inline-block text-left">
     <button
-      class="lang-selector inline-flex items-center justify-center px-2 py-2 border-2 border-[#548EF8] rounded text-sm font-medium text-[#548EF8] bg-transparent cursor-pointer focus:outline-none"
+      class="lang-selector inline-flex items-center justify-center px-2 py-2 border-2 border-[#548EF8] rounded text-sm font-bold text-[#548EF8] bg-transparent cursor-pointer focus:outline-none"
       (click)="toggle()"
       type="button"
     >
-      <span class="w-5 h-5 flex items-center justify-center rounded-full bg-gray-800 text-white text-[10px] font-semibold">{{ currentLang | uppercase }}</span>
-      <!-- {{ getLabel(currentLang) }} -->
+      {{ currentLang | uppercase }}
       <svg class="w-4 h-4 ml-2" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
       </svg>
@@ -17,8 +16,7 @@
         @for (lang of languages; track $index) {
           <button
             (click)="changeLang(lang.code)"
-            class="flex items-center w-full px-4 py-2 text-sm text-gray-700 rounded-md hover:bg-[#525086] hover:text-white cursor-pointer">
-            <span class="w-5 h-5 mr-2 flex items-center justify-center rounded-full bg-gray-800 text-white text-[10px] font-semibold">{{ lang.code | uppercase }}</span>
+            class="w-full px-4 py-2 text-sm text-gray-700 rounded-md hover:bg-[#525086] hover:text-white cursor-pointer">
             {{ lang.label }}
           </button>
         }

--- a/src/app/shell/language-selection/language-selection.component.scss
+++ b/src/app/shell/language-selection/language-selection.component.scss
@@ -1,5 +1,4 @@
 .lang-selector {
     &:hover {
-        box-shadow: inset 0 0 2px 2px #00000040;
-    }
-}
+        box-shadow: none;
+    }}

--- a/src/app/shell/navigation/navigation.component.html
+++ b/src/app/shell/navigation/navigation.component.html
@@ -1,7 +1,7 @@
 <nav class="bg-white sticky top-0 z-50">
     <div class="mx-auto max-w-6xl px-2 sm:px-6 lg:px-8">
       <div class="relative flex items-center justify-between py-9">
-        <div class="absolute inset-y-0 left-0 flex items-center sm:hidden">
+        <div class="absolute inset-y-0 right-0 flex items-center sm:hidden">
 
             <!-- Mobile menu button-->
           <button type="button" 
@@ -30,7 +30,7 @@
           </button>
 
         </div>
-        <div class="flex flex-1 items-center">
+        <div class="flex flex-1 items-center justify-center sm:justify-start">
           <div class="flex shrink-0 items-center">
             <a [routerLink]="['/']" class="flex items-center text-[#1680AC]" aria-label="Home">
                 <img src="/images/svg/logo-chip.svg" alt="Chip logo" class="w-[40px] h-[36px]" />

--- a/tailwindcss-config.js
+++ b/tailwindcss-config.js
@@ -5,10 +5,12 @@ module.exports = {
   ],
   theme: {
     extend: {
+      fontFamily: {
+        sans: ['Poppins', 'sans-serif'],
+      },
       backgroundImage: {
         'dark-horizontal': 'linear-gradient(to right, #0f1a20, #0f1b21, #0f1c22, #0f1d23, #0f1e24)',
       },
     },
   },
-  plugins: [],
-};
+  plugins: [],};


### PR DESCRIPTION
## Summary
- set Poppins as default font
- move mobile menu button to the right and center logo
- simplify language dropdown styling

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_686d7a67575c8320bbdb0c3828935546