### PR TITLE
Add brand logo carousel and move hero styles

### DIFF
--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -1,6 +1,5 @@
 <section [appScrollSpy]="'home'" id="home" class="relative">
-  <div class="max-w-7xl mx-auto grid grid-cols-1 md:grid-cols-2 gap-6 items-center px-4 pb-12 mt-12"
-    style="background-image: url('/images/hero-new-bg.png'); background-repeat: no-repeat; background-position: center right; background-size: contain;">
+  <div class="max-w-7xl mx-auto grid grid-cols-1 md:grid-cols-2 gap-6 items-center px-4 pb-12 mt-12 hero-bg">
     <div class="space-y-4 max-w-[570px]">
       <div class="flex flex-col sm:flex-row sm:items-center gap-2 text-[#548EF8]">
         <a href="https://www.instagram.com/chip.valencia" class="flex items-center gap-2 hover:underline">
@@ -17,6 +16,13 @@
       <p class="text-[#3C485B] text-[20px] leading-[32px] font-normal whitespace-pre-line">{{ 'HOME.HERO_SUBTITLE' | translate }}</p>
       <a href="#contacts" class="inline-block bg-[#548EF8] text-[#EEEFEF] px-6 py-3">{{ 'HOME.HERO_BUTTON' | translate }}</a>
     </div>
+  </div>
+</section>
+<section class="py-7 bg-white overflow-hidden">
+  <div class="brand-carousel flex w-max items-center gap-8">
+    @for (logo of logosRow; track $index) {
+      <img [src]="logo" alt="brand logo" class="h-12 w-auto" />
+    }
   </div>
 </section>
 <div class="dark-horizontal">
@@ -43,8 +49,8 @@
           </div>
 
           <div [class.lg:order-1]="$index % 2 !== 0">
-            <img loading="lazy" [src]="card.image" [attr.alt]="card.alt | translate" width="516" height="258" style="aspect-ratio: 16 / 9;"
-              class="rounded-xl shadow-lg w-full object-cover max-h-[400px]" />
+          <img loading="lazy" [src]="card.image" [attr.alt]="card.alt | translate" width="516" height="258"
+            class="rounded-xl shadow-lg w-full object-cover max-h-[400px] aspect-video" />
           </div>
 
         </div>

--- a/src/app/pages/home/home.component.scss
+++ b/src/app/pages/home/home.component.scss
@@ -1,0 +1,23 @@
+:host {
+  display: block;
+}
+
+.hero-bg {
+  background-image: url('/images/hero-new-bg.png');
+  background-repeat: no-repeat;
+  background-position: center right;
+  background-size: contain;
+}
+
+@keyframes scroll {
+  0% {
+    transform: translateX(0);
+  }
+  100% {
+    transform: translateX(-50%);
+  }
+}
+
+.brand-carousel {
+  animation: scroll 20s linear infinite;
+}

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -56,6 +56,17 @@ cards = [
   },
 ];
 
+logos = [
+  '/images/svg/apple.svg',
+  '/images/svg/asus.svg',
+  '/images/svg/huawei.svg',
+  '/images/svg/oppo.svg',
+  '/images/svg/samsung.svg',
+  '/images/svg/xaomi.svg',
+];
+
+logosRow = [...this.logos, ...this.logos];
+
   constructor(
     private route: ActivatedRoute,
     @Inject(PLATFORM_ID) private platformId: Object,


### PR DESCRIPTION
## Summary
- refactor hero section styles into SCSS
- add looping brand logos carousel below hero section
- remove inline aspect ratio style on images

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_686f1a8273ec8320bb11accc436be68b