### PR TITLE
Remove brand carousel

### DIFF
--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -18,9 +18,9 @@
     </div>
   </div>
 </section>
-<section class="py-7 bg-white overflow-hidden">
-  <div class="brand-carousel flex w-max items-center gap-60">
-    @for (logo of logosRow; track $index) {
+<section class="py-7 bg-white">
+  <div class="flex flex-wrap justify-center items-center gap-16">
+    @for (logo of logos; track $index) {
       <img [src]="logo" alt="brand logo" class="h-3 w-auto" />
     }
   </div>

--- a/src/app/pages/home/home.component.scss
+++ b/src/app/pages/home/home.component.scss
@@ -9,15 +9,5 @@
   background-size: contain;
 }
 
-@keyframes scroll {
-  0% {
-    transform: translateX(0);
-  }
-  100% {
-    transform: translateX(-50%);
-  }
-}
 
-.brand-carousel {
-  animation: scroll 20s linear infinite;
-}
+

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -65,8 +65,6 @@ logos = [
   '/images/svg/xaomi.svg',
 ];
 
-logosRow = [...this.logos, ...this.logos];
-
   constructor(
     private route: ActivatedRoute,
     @Inject(PLATFORM_ID) private platformId: Object,


### PR DESCRIPTION
## Summary
- remove carousel animation styles
- delete duplicated `logosRow` data
- show brand logos statically in a flex layout

## Testing
- `npm test --silent` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_686f202dfca88320a47d0368538c5796