### PR TITLE
Adjust mobile styles

### DIFF
--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -1,5 +1,5 @@
 <section [appScrollSpy]="'home'" id="home" class="relative">
-  <div class="max-w-7xl px-2 sm:px-6 lg:px-8 mx-auto grid grid-cols-1 md:grid-cols-2 gap-6 items-center pb-48 mt-12 hero-bg">
+  <div class="max-w-7xl px-2 sm:px-6 lg:px-8 mx-auto grid grid-cols-1 md:grid-cols-2 gap-6 items-center pb-24 sm:pb-48 mt-12 hero-bg">
     <div class="space-y-4">
       <div class="flex flex-col bg-white sm:flex-row sm:items-center gap-2 text-[#548EF8]">
         <a href="https://www.instagram.com/chip.valencia" class="flex items-center gap-2 hover:underline">
@@ -21,7 +21,7 @@
 <section class="py-7 bg-white overflow-hidden">
   <div class="brand-carousel flex w-max items-center gap-60">
     @for (logo of logosRow; track $index) {
-      <img [src]="logo" alt="brand logo" class="h-3 w-auto" />
+      <img [src]="logo" alt="brand logo" class="h-5 sm:h-3 w-auto" />
     }
   </div>
 </section>

--- a/src/app/pages/home/home.component.scss
+++ b/src/app/pages/home/home.component.scss
@@ -5,8 +5,15 @@
 .hero-bg {
   background-image: url('/images/hero-new-bg.png');
   background-repeat: no-repeat;
-  background-position: center right;
-  background-size: contain;
+  background-position: left;
+  background-size: cover;
+}
+
+@media (min-width: 640px) {
+  .hero-bg {
+    background-position: center right;
+    background-size: contain;
+  }
 }
 
 @keyframes scroll {

--- a/src/app/shell/navigation/navigation.component.html
+++ b/src/app/shell/navigation/navigation.component.html
@@ -1,6 +1,6 @@
 <nav class="bg-white sticky top-0 z-50">
-    <div class="mx-auto max-w-7xl px-2 sm:px-6 lg:px-8">
-      <div class="relative flex items-center justify-between py-9">
+    <div class="mx-auto max-w-7xl p-4 sm:px-6 lg:px-8">
+      <div class="relative flex items-center justify-between py-4 sm:py-9">
         <div class="absolute inset-y-0 right-0 flex items-center sm:hidden">
 
             <!-- Mobile menu button-->


### PR DESCRIPTION
## Summary
- tweak hero padding and brand logo size for mobile
- set hero background to left/cover on small screens
- reduce navbar padding on mobile

## Testing
- `npm test --silent` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_686f287799f88320a907319e1ed3ca7c