### PR TITLE
Add responsive feedback carousel

### DIFF
--- a/src/app/pages/home/feedback-carousel/feedback-carousel.component.html
+++ b/src/app/pages/home/feedback-carousel/feedback-carousel.component.html
@@ -2,9 +2,9 @@
   <div class="relative">
     <button type="button" (click)="prev()" class="absolute left-0 top-1/2 -translate-y-1/2 bg-white text-[#051937] text-[28px] rounded-full shadow z-10">&#8249;</button>
     <button type="button" (click)="next()" class="absolute right-0 top-1/2 -translate-y-1/2 bg-white text-[#051937] text-[28px] rounded-full shadow z-10">&#8250;</button>
-    <div class="overflow-hidden">
-      <div class="flex transition-transform duration-300" [style.transform]="'translateX(-' + (index * 25) + '%)'">
-        <div *ngFor="let t of testimonials" class="box-border p-4" style="flex: 0 0 25%">
+      <div class="overflow-hidden">
+        <div class="flex transition-transform duration-300" [style.transform]="'translateX(-' + (index * (100 / visible)) + '%)'">
+          <div *ngFor="let t of testimonials" class="box-border p-4" [style.flex]="'0 0 ' + (100 / visible) + '%'">
           <div class="bg-white shadow-md p-4 h-full flex flex-col">
             <div class="flex items-center mb-3">
               <img src="/images/feedback-user-placeholder.jpg" alt="user" class="w-12 h-12 rounded-full mr-3" />

--- a/src/app/pages/home/feedback-carousel/feedback-carousel.component.ts
+++ b/src/app/pages/home/feedback-carousel/feedback-carousel.component.ts
@@ -1,5 +1,5 @@
-import { CommonModule } from '@angular/common';
-import { Component } from '@angular/core';
+import { CommonModule, isPlatformBrowser } from '@angular/common';
+import { Component, HostListener, Inject, PLATFORM_ID } from '@angular/core';
 import { TestimonialsService } from '../../../shared/services/testimonials.service';
 import { TranslatePipe } from '@ngx-translate/core';
 
@@ -15,8 +15,37 @@ export class FeedbackCarouselComponent {
   index = 0;
   visible = 4;
 
-  constructor(private service: TestimonialsService) {
+  constructor(
+    private service: TestimonialsService,
+    @Inject(PLATFORM_ID) private platformId: Object
+  ) {
     this.testimonials = this.service.getTestimonials();
+    this.updateVisible();
+  }
+
+  @HostListener('window:resize')
+  onResize() {
+    this.updateVisible();
+  }
+
+  private updateVisible() {
+    if (isPlatformBrowser(this.platformId)) {
+      const width = window.innerWidth;
+      if (width < 640) {
+        this.visible = 1;
+      } else if (width < 1024) {
+        this.visible = 2;
+      } else if (width < 1280) {
+        this.visible = 3;
+      } else {
+        this.visible = 4;
+      }
+
+      const max = this.testimonials.length - this.visible;
+      if (this.index > max) {
+        this.index = Math.max(max, 0);
+      }
+    }
   }
 
   next() {


### PR DESCRIPTION
## Summary
- make feedback carousel responsive with width-based breakpoints
- dynamically adjust card width and translation

## Testing
- `npm test -- --watch=false` *(fails: Chrome missing)*

------
https://chatgpt.com/codex/tasks/task_e_6877832f24cc8320b28f7dfb98789991