### PR TITLE
Move captcha generation to server

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@ngx-translate/http-loader": "^16.0.1",
     "@popperjs/core": "^2.11.8",
     "@tailwindcss/postcss": "^4.1.4",
+    "canvas": "^3.1.2",
     "compression": "^1.8.0",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",

--- a/src/app/pages/contacts/contacts.component.html
+++ b/src/app/pages/contacts/contacts.component.html
@@ -49,7 +49,11 @@
           <textarea formControlName="description" rows="4" class="w-full bg-[#EEEFEF] text-[#3C485B] px-3 py-2"></textarea>
         </div>
         <div>
-          <label class="block mb-1 text-[14px] leading-[20px] font-normal">{{ 'CONTACTS.CAPTCHA' | translate }}: {{ captchaA }} + {{ captchaB }} = ?</label>
+          <label class="block mb-1 text-[14px] leading-[20px] font-normal">{{ 'CONTACTS.CAPTCHA' | translate }}</label>
+          <div class="flex items-center gap-2 mb-1">
+            <img [src]="captchaImage" alt="captcha" class="h-10" />
+            <button type="button" (click)="loadCaptcha()" aria-label="refresh captcha">&#x21bb;</button>
+          </div>
           <input formControlName="captcha" type="text" class="w-full bg-[#EEEFEF] text-[#3C485B] px-3 py-2" />
           @if (captchaError) {
             <div class="text-red-200 text-sm">{{ 'CONTACTS.CAPTCHA_ERROR' | translate }}</div>

--- a/src/app/pages/contacts/contacts.component.spec.ts
+++ b/src/app/pages/contacts/contacts.component.spec.ts
@@ -4,6 +4,8 @@ import { TranslateModule } from '@ngx-translate/core';
 
 import { ContactsComponent } from './contacts.component';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { of, throwError } from 'rxjs';
+import { ContactService } from '../../shared/services/contact.service';
 
 describe('ContactsComponent', () => {
   let component: ContactsComponent;
@@ -29,13 +31,25 @@ describe('ContactsComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should set captchaError when answer is wrong', () => {
+  it('should load captcha on init', () => {
+    const service = TestBed.inject(ContactService);
+    const spy = spyOn(service, 'getCaptcha').and.returnValue(of({ id: '1', image: 'data' }));
+    component.ngOnInit();
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('should set captchaError when server rejects captcha', () => {
+    const service = TestBed.inject(ContactService);
+    spyOn(service, 'getCaptcha').and.returnValue(of({ id: '1', image: 'data' }));
+    spyOn(service, 'sendRequest').and.returnValue(throwError(() => ({ status: 400 })));
+
+    component.ngOnInit();
     component.requestForm.setValue({
       name: 'Test',
       phone: '123',
       model: '',
       description: '',
-      captcha: 0
+      captcha: '0'
     });
 
     component.submitRequest();

--- a/src/app/shared/services/contact.service.ts
+++ b/src/app/shared/services/contact.service.ts
@@ -7,11 +7,17 @@ export interface ContactRequest {
   phone: string;
   model: string;
   description: string;
+  captchaId: string;
+  captcha: string;
 }
 
 @Injectable({ providedIn: 'root' })
 export class ContactService {
   constructor(private http: HttpClient) {}
+
+  getCaptcha(): Observable<{ id: string; image: string }> {
+    return this.http.get<{ id: string; image: string }>('/api/captcha');
+  }
 
   sendRequest(data: ContactRequest): Observable<any> {
     return this.http.post('/api/contact', data);

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,6 +10,8 @@ import { readFileSync } from 'node:fs';
 import compression from 'compression';
 import nodemailer from 'nodemailer';
 import dotenv from 'dotenv';
+import { createCanvas } from 'canvas';
+import crypto from 'node:crypto';
 
 dotenv.config();
 
@@ -23,6 +25,9 @@ const app = express();
 const angularApp = new AngularNodeAppEngine();
 
 app.use(compression());
+
+type CaptchaEntry = { answer: number; timeout: NodeJS.Timeout };
+const captchaMap = new Map<string, CaptchaEntry>();
 
 const transporter = nodemailer.createTransport({
   host: process.env['SMTP_HOST'],
@@ -56,8 +61,43 @@ app.use(
   }),
 );
 
+app.get('/api/captcha', (_req, res) => {
+  const a = Math.floor(Math.random() * 10) + 1;
+  const b = Math.floor(Math.random() * 10) + 1;
+  const answer = a + b;
+
+  const canvas = createCanvas(100, 40);
+  const ctx = canvas.getContext('2d');
+  ctx.fillStyle = '#ffffff';
+  ctx.fillRect(0, 0, 100, 40);
+  ctx.fillStyle = '#000000';
+  ctx.font = '24px Arial';
+  ctx.fillText(`${a} + ${b} = ?`, 10, 28);
+
+  const image = canvas.toDataURL();
+  const id = crypto.randomUUID();
+  const timeout = setTimeout(() => {
+    captchaMap.delete(id);
+  }, 5 * 60 * 1000);
+
+  captchaMap.set(id, { answer, timeout });
+  res.json({ id, image });
+});
+
 app.post('/api/contact', express.json(), async (req, res) => {
-  const { name, phone, model, description } = req.body;
+  const { name, phone, model, description, captchaId, captcha } = req.body;
+  const entry = captchaMap.get(captchaId);
+  if (!entry || entry.answer !== Number(captcha)) {
+    if (entry) {
+      clearTimeout(entry.timeout);
+      captchaMap.delete(captchaId);
+    }
+    return res.status(400).json({ success: false, captcha: false });
+  }
+
+  clearTimeout(entry.timeout);
+  captchaMap.delete(captchaId);
+
   try {
     await transporter.sendMail({
       from: process.env['SMTP_USER'],


### PR DESCRIPTION
## Summary
- generate captcha images server-side with canvas
- validate captcha solution on the server
- refresh captcha from the frontend
- update tests for new captcha flow
- add `canvas` dependency

## Testing
- `npm test` *(fails: Angular compilation initialization failed)*

------
https://chatgpt.com/codex/tasks/task_e_6883b7f5cb588320ba6564ba2dfbac06