### PR TITLE
Fix labels for accessibility

### DIFF
--- a/src/app/pages/contacts/contacts.component.html
+++ b/src/app/pages/contacts/contacts.component.html
@@ -27,26 +27,26 @@
       <h3 class="text-[32px] leading-[48px] font-semibold mb-6">{{ 'CONTACTS.FORM_TITLE' | translate }}</h3>
       <form [formGroup]="requestForm" (ngSubmit)="submitRequest()" class="space-y-4 flex-1">
         <div>
-          <label class="block mb-1 text-[14px] leading-[20px] font-normal">{{ 'CONTACTS.NAME' | translate }}</label>
-          <input formControlName="name" type="text" class="w-full bg-[#EEEFEF] text-[#3C485B] px-3 py-2" />
+          <label for="contact-name" class="block mb-1 text-[14px] leading-[20px] font-normal">{{ 'CONTACTS.NAME' | translate }}</label>
+          <input id="contact-name" formControlName="name" type="text" class="w-full bg-[#EEEFEF] text-[#3C485B] px-3 py-2" />
           @if (requestForm.get('name')?.touched && requestForm.get('name')?.invalid) {
             <div class="text-red-200 text-sm">*</div>
           }
         </div>
         <div>
-          <label class="block mb-1 text-[14px] leading-[20px] font-normal">{{ 'CONTACTS.PHONE' | translate }}</label>
-          <input formControlName="phone" type="tel" class="w-full bg-[#EEEFEF] text-[#3C485B] px-3 py-2" />
+          <label for="contact-phone" class="block mb-1 text-[14px] leading-[20px] font-normal">{{ 'CONTACTS.PHONE' | translate }}</label>
+          <input id="contact-phone" formControlName="phone" type="tel" class="w-full bg-[#EEEFEF] text-[#3C485B] px-3 py-2" />
           @if (requestForm.get('phone')?.touched && requestForm.get('phone')?.invalid) {
             <div class="text-red-200 text-sm">*</div>
           }
         </div>
         <div>
-          <label class="block mb-1 text-[14px] leading-[20px] font-normal">{{ 'CONTACTS.MODEL' | translate }}</label>
-          <input formControlName="model" type="text" class="w-full bg-[#EEEFEF] text-[#3C485B] px-3 py-2" />
+          <label for="contact-model" class="block mb-1 text-[14px] leading-[20px] font-normal">{{ 'CONTACTS.MODEL' | translate }}</label>
+          <input id="contact-model" formControlName="model" type="text" class="w-full bg-[#EEEFEF] text-[#3C485B] px-3 py-2" />
         </div>
         <div class="flex-1">
-          <label class="block mb-1 text-[14px] leading-[20px] font-normal">{{ 'CONTACTS.DESCRIPTION' | translate }}</label>
-          <textarea formControlName="description" rows="4" class="w-full bg-[#EEEFEF] text-[#3C485B] px-3 py-2"></textarea>
+          <label for="contact-description" class="block mb-1 text-[14px] leading-[20px] font-normal">{{ 'CONTACTS.DESCRIPTION' | translate }}</label>
+          <textarea id="contact-description" formControlName="description" rows="4" class="w-full bg-[#EEEFEF] text-[#3C485B] px-3 py-2"></textarea>
         </div>
         <div>
           <label class="block mb-1 text-[14px] leading-[20px] font-normal">{{ 'CONTACTS.CAPTCHA' | translate }}</label>

--- a/src/app/pages/status/status.component.html
+++ b/src/app/pages/status/status.component.html
@@ -5,8 +5,9 @@
   
       <form (ngSubmit)="checkStatus()" [formGroup]="statusForm" class="space-y-4">
         <div>
-          <label class="block mb-1 font-medium">Номер заказа</label>
+          <label for="status-order-id" class="block mb-1 font-medium">Номер заказа</label>
           <input
+            id="status-order-id"
             formControlName="orderId"
             type="text"
             placeholder="Например: 123456"
@@ -18,8 +19,9 @@
         </div>
   
         <div>
-          <label class="block mb-1 font-medium">Код клиента</label>
+          <label for="status-pin" class="block mb-1 font-medium">Код клиента</label>
           <input
+            id="status-pin"
             formControlName="pin"
             type="password"
             placeholder="4-значный код"


### PR DESCRIPTION
## Summary
- connect labels to form inputs in contact and status pages for better accessibility

## Testing
- `npm test --silent` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_688523410e1c8320bf3658e8cae70a67