### PR TITLE
Replace ng-recaptcha with JS API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "compression": "^1.8.0",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
-        "ng-recaptcha": "^13.2.1",
         "ngx-toastr": "^19.0.0",
         "nodemailer": "^6.9.11",
         "postcss": "^8.5.3",
@@ -7715,19 +7714,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/ng-recaptcha": {
-      "version": "13.2.1",
-      "resolved": "https://registry.npmjs.org/ng-recaptcha/-/ng-recaptcha-13.2.1.tgz",
-      "integrity": "sha512-aBOoFla9t6AfT9t5paykoXomCDKreBKouB16VUFxSZwn1RCfDsdcaTmSNJKYLFz5j0Cq/V+szY9f3mHLgzRw5Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/grecaptcha": "^3.0.7",
-        "tslib": "^2.2.0"
-      },
-      "peerDependencies": {
-        "@angular/core": "^17.0.0"
       }
     },
     "node_modules/ngx-toastr": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "compression": "^1.8.0",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
-    "ng-recaptcha": "^13.2.1",
     "ngx-toastr": "^19.0.0",
     "nodemailer": "^6.9.11",
     "postcss": "^8.5.3",

--- a/src/app/pages/contacts/contacts.component.html
+++ b/src/app/pages/contacts/contacts.component.html
@@ -50,7 +50,7 @@
         </div>
         <div>
           <label class="block mb-1 text-[14px] leading-[20px] font-normal">{{ 'CONTACTS.CAPTCHA' | translate }}</label>
-          <re-captcha (resolved)="onCaptchaResolved($event)" [siteKey]="siteKey"></re-captcha>
+          <div #captchaRef></div>
           @if (captchaError) {
             <div class="text-red-200 text-sm">{{ 'CONTACTS.CAPTCHA_ERROR' | translate }}</div>
           }

--- a/src/app/pages/contacts/contacts.component.spec.ts
+++ b/src/app/pages/contacts/contacts.component.spec.ts
@@ -14,6 +14,9 @@ describe('ContactsComponent', () => {
   let fixture: ComponentFixture<ContactsComponent>;
 
   beforeEach(async () => {
+    (window as any).grecaptcha = {
+      render: () => 0,
+    };
     await TestBed.configureTestingModule({
       imports: [
         ContactsComponent,


### PR DESCRIPTION
## Summary
- remove ng-recaptcha dependency
- create a manual reCAPTCHA widget in the Contacts page
- reset captcha widget after form submission
- adjust unit test to stub `grecaptcha`

## Testing
- `npx ng test --watch=false` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_6886da69d2d08320a0d0686a750b5d6a