### PR TITLE
feat: add contact form with conditional captcha

### DIFF
--- a/src/app/pages/contacts/contacts.component.html
+++ b/src/app/pages/contacts/contacts.component.html
@@ -45,6 +45,40 @@
         </span>
       </a>
     </div>
+
+    <div class="mt-8 max-w-md mx-auto">
+      <form [formGroup]="contactForm" (ngSubmit)="submitRequest()" class="space-y-4">
+        <div>
+          <input
+            type="text"
+            formControlName="name"
+            placeholder="Имя"
+            class="w-full px-4 py-2 rounded-md text-gray-800"
+          />
+        </div>
+        <div>
+          <input
+            type="tel"
+            formControlName="phone"
+            placeholder="Телефон"
+            class="w-full px-4 py-2 rounded-md text-gray-800"
+          />
+        </div>
+        <div>
+          <textarea
+            formControlName="message"
+            placeholder="Комментарий"
+            class="w-full px-4 py-2 rounded-md text-gray-800"
+          ></textarea>
+        </div>
+        <div *ngIf="captchaRequired" class="text-center">
+          <p class="mb-2">Подтвердите, что вы не робот</p>
+          <div id="recaptcha"></div>
+        </div>
+        <button type="submit" class="w-full py-2 bg-yellow-600 text-white rounded-md">Отправить</button>
+        <p *ngIf="submitted" class="text-green-500 text-center">Заявка отправлена!</p>
+      </form>
+    </div>
   </section>
 
   

--- a/src/app/pages/contacts/contacts.component.ts
+++ b/src/app/pages/contacts/contacts.component.ts
@@ -2,14 +2,45 @@ import { Component } from '@angular/core';
 import { NgbScrollSpyModule } from '@ng-bootstrap/ng-bootstrap';
 import { ScrollspyDirective } from '../../shared/directives/scrollspy.directive';
 import { TranslateModule } from '@ngx-translate/core';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { HttpClient, HttpClientModule } from '@angular/common/http';
 
 @Component({
   selector: 'app-contacts',
-  imports: [ NgbScrollSpyModule, ScrollspyDirective, TranslateModule ],
+  imports: [
+    NgbScrollSpyModule,
+    ScrollspyDirective,
+    TranslateModule,
+    ReactiveFormsModule,
+    HttpClientModule
+  ],
   templateUrl: './contacts.component.html',
   styleUrl: './contacts.component.scss',
   standalone: true
 })
 export class ContactsComponent {
+  contactForm: FormGroup;
+  submitted = false;
+  captchaRequired = false;
 
+  constructor(private fb: FormBuilder, private http: HttpClient) {
+    this.contactForm = this.fb.group({
+      name: ['', Validators.required],
+      phone: ['', Validators.required],
+      message: ['']
+    });
+  }
+
+  submitRequest() {
+    if (this.contactForm.invalid) {
+      this.contactForm.markAllAsTouched();
+      return;
+    }
+
+    // Placeholder for backend call
+    // this.http.post('/api/contact', this.contactForm.value).subscribe();
+    console.log('Request submitted', this.contactForm.value);
+    this.submitted = true;
+    this.contactForm.reset();
+  }
 }


### PR DESCRIPTION
## Summary
- add contact form powered by reactive forms and placeholder submit logic
- hide captcha prompt when verification is not required

## Testing
- `npx ng test --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser)*

------
https://chatgpt.com/codex/tasks/task_e_68b08f2e8000832080050eb35a655471