### PR TITLE
Handle optional captcha and request submission

### DIFF
--- a/src/app/pages/contacts/contacts.component.html
+++ b/src/app/pages/contacts/contacts.component.html
@@ -48,13 +48,15 @@
           <label for="contact-description" class="block mb-1 text-[14px] leading-[20px] font-normal">{{ 'CONTACTS.DESCRIPTION' | translate }}</label>
           <textarea id="contact-description" formControlName="description" rows="4" class="w-full bg-[#EEEFEF] text-[#3C485B] px-3 py-2"></textarea>
         </div>
-        <div>
-          <label class="block mb-1 text-[14px] leading-[20px] font-normal">{{ 'CONTACTS.CAPTCHA' | translate }}</label>
-          <div #captchaRef></div>
-          @if (captchaError) {
-            <div class="text-red-200 text-sm">{{ 'CONTACTS.CAPTCHA_ERROR' | translate }}</div>
-          }
-        </div>
+        @if (captchaRequired) {
+          <div>
+            <label class="block mb-1 text-[14px] leading-[20px] font-normal">{{ 'CONTACTS.CAPTCHA' | translate }}</label>
+            <div #captchaRef></div>
+            @if (captchaError) {
+              <div class="text-red-200 text-sm">{{ 'CONTACTS.CAPTCHA_ERROR' | translate }}</div>
+            }
+          </div>
+        }
         <button type="submit" [attr.disabled]="!requestForm.valid || captchaError || loading"
           class="mt-2 bg-[#A8EB12] hover:bg-[#83BB11] hover:cursor-pointer text-[#051937] font-semibold text-[16px] leading-[24px] px-6 py-3 flex items-center justify-center"
           [class.opacity-50]="!requestForm.valid || captchaError || loading">

--- a/src/app/pages/contacts/contacts.component.ts
+++ b/src/app/pages/contacts/contacts.component.ts
@@ -22,6 +22,7 @@ export class ContactsComponent implements OnInit, AfterViewInit {
   captchaToken = '';
   // Using Google's test site key for reCAPTCHA v2
   siteKey = '6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI';
+  captchaRequired = false;
   captchaError = false;
   loading = false;
   recaptchaWidgetId?: number;
@@ -50,6 +51,7 @@ export class ContactsComponent implements OnInit, AfterViewInit {
       typeof grecaptcha !== 'undefined' &&
       this.captchaElem
     ) {
+      this.captchaRequired = true;
       this.recaptchaWidgetId = grecaptcha.render(
         this.captchaElem.nativeElement,
         {
@@ -70,11 +72,17 @@ export class ContactsComponent implements OnInit, AfterViewInit {
 
   submitRequest() {
     if (this.requestForm.valid) {
+      if (this.captchaRequired && !this.captchaToken) {
+        this.captchaError = true;
+        return;
+      }
       this.loading = true;
-      const payload = {
+      const payload: any = {
         ...this.requestForm.value,
-        token: this.captchaToken,
       };
+      if (this.captchaRequired) {
+        payload.token = this.captchaToken;
+      }
       this.contact.sendRequest(payload)
         .pipe(finalize(() => (this.loading = false)))
         .subscribe({
@@ -84,7 +92,7 @@ export class ContactsComponent implements OnInit, AfterViewInit {
           this.toastr.success(msg);
           this.requestForm.reset();
           this.captchaToken = '';
-          if (this.recaptchaWidgetId !== undefined) {
+          if (this.captchaRequired && this.recaptchaWidgetId !== undefined) {
             grecaptcha.reset(this.recaptchaWidgetId);
           }
         },
@@ -93,14 +101,14 @@ export class ContactsComponent implements OnInit, AfterViewInit {
             this.captchaError = true;
           }
           console.error('Request failed', err);
-          if (this.recaptchaWidgetId !== undefined) {
+          if (this.captchaRequired && this.recaptchaWidgetId !== undefined) {
             grecaptcha.reset(this.recaptchaWidgetId);
           }
         }
       });
     } else {
       this.toastr.error(this.translate.instant('CONTACTS.FORM_INVALID'));
-      this.captchaError = true;
+      this.captchaError = this.captchaRequired;
     }
   }
 }

--- a/src/app/shared/services/contact.service.ts
+++ b/src/app/shared/services/contact.service.ts
@@ -7,7 +7,7 @@ export interface ContactRequest {
   phone: string;
   model: string;
   description: string;
-  token: string;
+  token?: string;
 }
 
 @Injectable({ providedIn: 'root' })

--- a/src/server.ts
+++ b/src/server.ts
@@ -60,20 +60,22 @@ app.use(
 app.post('/api/contact', express.json(), async (req, res) => {
   const { name, phone, model, description, token } = req.body;
 
-  try {
-    const secret = process.env['RECAPTCHA_SECRET'];
-    const verify = await fetch('https://www.google.com/recaptcha/api/siteverify', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      body: `secret=${secret}&response=${token}`,
-    });
-    const result = await verify.json();
-    if (!result.success) {
-      return res.status(400).json({ success: false, captcha: false });
+  if (token) {
+    try {
+      const secret = process.env['RECAPTCHA_SECRET'];
+      const verify = await fetch('https://www.google.com/recaptcha/api/siteverify', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: `secret=${secret}&response=${token}`,
+      });
+      const result = await verify.json();
+      if (!result.success) {
+        return res.status(400).json({ success: false, captcha: false });
+      }
+    } catch (verifyErr) {
+      console.error('Failed to verify captcha', verifyErr);
+      return res.status(500).json({ success: false });
     }
-  } catch (verifyErr) {
-    console.error('Failed to verify captcha', verifyErr);
-    return res.status(500).json({ success: false });
   }
 
   try {


### PR DESCRIPTION
## Summary
- Skip server-side captcha verification when no token is provided
- Allow contact requests without captcha and hide captcha prompt when unused
- Send captcha token only when available

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: ChromeHeadless binary requires snap install)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b0a2cd8a9c8320a85cdc0fa5099994